### PR TITLE
Remove reference to non-existing covariate.

### DIFF
--- a/tutorials/introduction/simulating_populations.jmd
+++ b/tutorials/introduction/simulating_populations.jmd
@@ -181,10 +181,9 @@ do that, let's dive into covariate generation.
 ### Covariates
 
 As was discussed earlier, a `Subject` can also be provided details regarding
-covariates. In the model above, there are two covariates, `isPM` which stands
-for _is the subject a poor metabolizer_ and takes a boolean of _yes_ and  _no_.
-The second covariate is a continuous covariate where body weight `Wt` impacts
-both `CL` and `V`. Let us now specify covariates to a population of 10 subjects.
+covariates. In the model above, there is one, continuous, covariate where the
+body weight `Wt` impacts both `CL` and `V`.  Let us now specify covariates to a
+population of 10 subjects.
 
 ```julia
 choose_covariates() = (Wt = rand(55:80),)


### PR DESCRIPTION
Fix a description that references a covariate not present in the model. 